### PR TITLE
fix(postgres): Fix stockLocationId migration

### DIFF
--- a/src/migrations/1679907976277-v2-postgres.ts
+++ b/src/migrations/1679907976277-v2-postgres.ts
@@ -22,7 +22,7 @@ export class postgresV231679907976277 implements MigrationInterface {
         // await queryRunner.query("ALTER TABLE `stock_movement` RENAME COLUMN `orderItemId` TO `stockLocationId`", undefined);
         //
         // Replace it with:
-        await queryRunner.query(`ALTER TABLE "stock_movement" ADD "stockLocationId" integer`);
+        await queryRunner.query(`ALTER TABLE "stock_movement" ADD "stockLocationId" uuid NOT NULL`);
 
         await queryRunner.query(`CREATE TABLE "seller" ("createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP, "name" character varying NOT NULL, "id" SERIAL NOT NULL, CONSTRAINT "PK_36445a9c6e794945a4a4a8d3c9d" PRIMARY KEY ("id"))`);
         await queryRunner.query(`CREATE TABLE "stock_location" ("createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "name" character varying NOT NULL, "description" character varying NOT NULL, "id" SERIAL NOT NULL, CONSTRAINT "PK_adf770067d0df1421f525fa25cc" PRIMARY KEY ("id"))`);

--- a/src/migrations/1679907976277-v2-postgres.ts
+++ b/src/migrations/1679907976277-v2-postgres.ts
@@ -21,7 +21,7 @@ export class postgresV231679907976277 implements MigrationInterface {
         //
         // await queryRunner.query("ALTER TABLE `stock_movement` RENAME COLUMN `orderItemId` TO `stockLocationId`", undefined);
         //
-        // Replace it with the line below if you are using the default value (AutoIncrementIdStrategy) for the entityIdStrategy
+        // Replace it with the line below if you are using the default value (AutoIncrementIdStrategy) for the entityIdStrategy:
         await queryRunner.query(`ALTER TABLE "stock_movement" ADD "stockLocationId" integer`);
         // Or if you are using UuidIdStrategy as entityIdStrategy, replace it with:
         // await queryRunner.query(`ALTER TABLE "stock_movement" ADD "stockLocationId" uuid NOT NULL`);

--- a/src/migrations/1679907976277-v2-postgres.ts
+++ b/src/migrations/1679907976277-v2-postgres.ts
@@ -21,8 +21,10 @@ export class postgresV231679907976277 implements MigrationInterface {
         //
         // await queryRunner.query("ALTER TABLE `stock_movement` RENAME COLUMN `orderItemId` TO `stockLocationId`", undefined);
         //
-        // Replace it with:
-        await queryRunner.query(`ALTER TABLE "stock_movement" ADD "stockLocationId" uuid NOT NULL`);
+        // Replace it with the line below if you are using the default value (AutoIncrementIdStrategy) for the entityIdStrategy
+        await queryRunner.query(`ALTER TABLE "stock_movement" ADD "stockLocationId" integer`);
+        // Or if you are using UuidIdStrategy as entityIdStrategy, replace it with:
+        // await queryRunner.query(`ALTER TABLE "stock_movement" ADD "stockLocationId" uuid NOT NULL`);
 
         await queryRunner.query(`CREATE TABLE "seller" ("createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP, "name" character varying NOT NULL, "id" SERIAL NOT NULL, CONSTRAINT "PK_36445a9c6e794945a4a4a8d3c9d" PRIMARY KEY ("id"))`);
         await queryRunner.query(`CREATE TABLE "stock_location" ("createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "name" character varying NOT NULL, "description" character varying NOT NULL, "id" SERIAL NOT NULL, CONSTRAINT "PK_adf770067d0df1421f525fa25cc" PRIMARY KEY ("id"))`);


### PR DESCRIPTION
I’m trying the new Vendure beta-2 and following the db migration [doc](https://github.com/vendure-ecommerce/v2-migration-tool/blob/master/README.md#migrating-your-db-from-vendure-v1-to-v2), we cannot execute this line: https://github.com/vendure-ecommerce/v2-migration-tool/blob/master/src/migrations/1679907976277-v2-postgres.ts#L137
because of this previous line: https://github.com/vendure-ecommerce/v2-migration-tool/blob/master/src/migrations/1679907976277-v2-postgres.ts#L25 
The error is `Key columns "stockLocationId" and "id" are of incompatible types: integer and uuid.`, so this PR fix it.
